### PR TITLE
Adds --generate-compile-commands flag to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ local_todo
 bin/*
 err/
 test/testProject
+test/.cache
 test/.hcache
+test/.vscode
+.cache
 .hcache
+.vscode
 target
+
+compile_commands.json

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,5 +1,0 @@
--std=c++23
--Wall
--Wextra
--Werror
--Iprivate

--- a/hewg.scl
+++ b/hewg.scl
@@ -55,6 +55,7 @@ sources =
     "compile.cc"
     "link.cc"
 
+    "compile_commands.cc"
     "build.cc"
     "init.cc"
     "hooks.cc"

--- a/private/cmdline.hh
+++ b/private/cmdline.hh
@@ -75,6 +75,7 @@ struct BuildOptions : terse::TerminalSubcommand
 
   bool help = false;
   bool release = false;
+  bool generate_compile_commands = false;
 
   using options = std::tuple<
     terse::Option<"help", 'h', "prints this help", &BuildOptions::help>,
@@ -82,7 +83,11 @@ struct BuildOptions : terse::TerminalSubcommand
                   std::nullopt,
                   "changes the build type to release mode, enabling "
                   "all optimizations and stripping",
-                  &BuildOptions::release>>;
+                  &BuildOptions::release>,
+    terse::Option<"generate-compile-commands",
+                  std::nullopt,
+                  "generates a compile_commands.json for a given project, then exits",
+                  &BuildOptions::generate_compile_commands>>;
 };
 
 struct ToplevelOptions : terse::NonterminalSubcommand

--- a/private/compile_commands.hh
+++ b/private/compile_commands.hh
@@ -1,0 +1,20 @@
+
+
+#include <jayson.hh>
+#include <string>
+#include <vector>
+
+struct CompileCommand
+{
+  std::string directory;
+  std::vector<std::string> arguments;
+  std::string file;
+
+  using jayson_fields =
+    std::tuple<jayson::obj_field<"directory", &CompileCommand::directory>,
+               jayson::obj_field<"arguments", &CompileCommand::arguments>,
+               jayson::obj_field<"file", &CompileCommand::file>>;
+};
+
+std::string
+serialize_compile_commands(std::vector<CompileCommand> commands);

--- a/src/compile_commands.cc
+++ b/src/compile_commands.cc
@@ -1,0 +1,9 @@
+#include "compile_commands.hh"
+#include <jayson.hh>
+
+
+std::string
+serialize_compile_commands(std::vector<CompileCommand> commands)
+{
+    return jayson::serialize(commands).serialize(true);
+}


### PR DESCRIPTION
Run `hewg build --generate-compile-commands` to generate a `compile_commands.json` for use with clangd.

Also added a few things to the gitignore to exclude clangd and vscod(e/ium) stuff.