### PR TITLE
Cleanup for compile_commands_json branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ SRCS=src/main.cc \
 	src/compile.cc \
 	src/analysis.cc \
 	src/thread_pool.cc \
+	src/compile_commands.cc \
 	src/build.cc \
 	src/link.cc \
 	src/init.cc \

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,5 @@
+-std=c++23
+-Wall
+-Wextra
+-Werror
+-Iprivate

--- a/private/compile_commands.hh
+++ b/private/compile_commands.hh
@@ -17,4 +17,4 @@ struct CompileCommand
 };
 
 std::string
-serialize_compile_commands(std::vector<CompileCommand> commands);
+serialize_compile_commands(std::vector<CompileCommand> const& commands);

--- a/src/compile_commands.cc
+++ b/src/compile_commands.cc
@@ -3,7 +3,7 @@
 
 
 std::string
-serialize_compile_commands(std::vector<CompileCommand> commands)
+serialize_compile_commands(std::vector<CompileCommand> const& commands)
 {
     return jayson::serialize(commands).serialize(true);
 }


### PR DESCRIPTION
Fixes fresh builds (using make) broken by #8 and adds a minor optimization to serialize_compile_commands